### PR TITLE
Fix register struct overwrites when multiple peripherals contain a register with the same name

### DIFF
--- a/src/main/java/svd/task/SvdDataTypesCreateTask.java
+++ b/src/main/java/svd/task/SvdDataTypesCreateTask.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.data.CategoryPath;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeConflictHandler;
 import ghidra.program.model.data.InvalidDataTypeException;
@@ -126,16 +127,17 @@ public class SvdDataTypesCreateTask extends Task {
 
 	private StructureDataType createPeripheralBlockDataType(SvdPeripheral periph, SvdAddressBlock block) {
 		String struct_name = getPeriphBlockDataTypeName(periph, block);
-		StructureDataType struct = new StructureDataType(struct_name, block.getSize().intValue());
+		CategoryPath path = new CategoryPath("/" + periph.getName());
+		StructureDataType struct = new StructureDataType(path, struct_name, block.getSize().intValue());
 		for (SvdRegister reg : periph.getRegisters())
 			// TODO: Handle out of bounds values?
 			if (reg.getOffset() < block.getSize())
-				struct.replaceAtOffset(reg.getOffset(), createRegisterDataType(reg), reg.getSize() / 8, reg.getName(),
+				struct.replaceAtOffset(reg.getOffset(), createRegisterDataType(periph, reg), reg.getSize() / 8, reg.getName(),
 						reg.getDescription());
 		return struct;
 	}
 
-	private DataType createRegisterDataType(SvdRegister reg) {
+	private DataType createRegisterDataType(SvdPeripheral periph, SvdRegister reg) {
 		List<SvdField> fields = reg.getFields();
 
 		// If this is a register without fields, return the basic unsigned type...
@@ -143,7 +145,8 @@ public class SvdDataTypesCreateTask extends Task {
 			return new UnsignedLongDataType();
 
 		// Fields, insert bit fields at their exact bit offsets...
-		StructureDataType struct = new StructureDataType(reg.getName() + "_t", reg.getSize() / 8);
+		CategoryPath path = new CategoryPath("/" + periph.getName());
+		StructureDataType struct = new StructureDataType(path, reg.getName() + "_t", reg.getSize() / 8);
 		struct.setPackingEnabled(true);
 		fields.sort(Comparator.comparingInt(SvdField::getBitOffset));
 		int fieldNumber = 0;


### PR DESCRIPTION
If an SVD file contains multiple definitions of a given register name across different peripherals, the register bitfield structure is recreated and overwrites the existing one. The binary example used below accesses the RCC peripheral. 

This leads the following which is incorrect:
```
                             //
                             // RCC
                             // Generated by SVD
                             // ram:40023800-ram:40023bff
                             //
                             Peripherals::RCC                                XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                          FUN_080006c8:080006de(*)  
        40023800                 RCC_regi
           40023800                 CR_t                              CR                                XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                     FUN_080006c8:080006de(*)  
              40023800                 ulong:2   ??                      SPDIFEN       Peripheral Block E  XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      RXDMAEN       Receiver DMA ENabl  XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                     flow               FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      RXSTEO        STerEO Mode         XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023800                 ulong:2   ??                      DRFMT         RX Data format      XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      PMSK          Mask Parity error   XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      VMSK          Mask of Validity bitXREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023801                 ulong:1   ??                      CUMSK         Mask of channel st
                                                                                                     bits
              40023801                 ulong:1   ??                      PTMSK         Mask of Preamble T
              40023801                 ulong:1   ??                      CBDMAEN       Control Buffer DMA
                                                                                                     flow
              40023801                 ulong:1   ??                      CHSEL         Channel Selection
              40023801                 ulong:2   ??                      NBTR          Maximum allowed re
                                                                                                     sync
              40023801                 ulong:1   ??                      WFA           Wait For Activity
              40023801                 ulong:1   ??                      field12_0x1
              40023802                 ulong:3   ??                      INSEL         input selection

```

Following my changes the correct registers are now output:
```
                             //
                             // RCC
                             // Generated by SVD
                             // ram:40023800-ram:40023bff
                             //
                             Peripherals::RCC                                XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                          FUN_080006c8:080006de(*)  
        40023800                 RCC_regi
           40023800                 CR_t                              CR                                XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                     FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      HSION         Internal high-spee  XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                     enable             FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      HSIRDY        Internal high-spee  XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                     flag               FUN_080006c8:080006de(*)  
              40023800                 ulong:1   ??                      field2_0x0                        XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                                        FUN_080006c8:080006de(*)  
              40023800                 ulong:5   ??                      HSITRIM       Internal high-spee  XREF[2]:     FUN_080006c8:080006d6(*), 
                                                                                                     trim               FUN_080006c8:080006de(*)  
              40023801                 ulong:8   ??                      HSICAL        Internal high-spee
                                                                                                     cali
              40023802                 ulong:1   ??                      HSEON         HSE clock enable
              40023802                 ulong:1   ??                      HSERDY        HSE clock ready flag
              40023802                 ulong:1   ??                      HSEBYP        HSE clock bypass
              40023802                 ulong:1   ??                      CSSON         Clock security sys
                                                                                                     enable
              40023802                 ulong:4   ??                      field9_0x2
              40023803                 ulong:1   ??                      PLLON         Main PLL (PLL) ena
              40023803                 ulong:1   ??                      PLLRDY        Main PLL (PLL) clo
                                                                                                     flag
              40023803                 ulong:1   ??                      PLLI2SON      PLLI2S enable
              40023803                 ulong:1   ??                      PLLI2SRDY     PLLI2S clock ready

```

This also has the nice side effect of organising the registers that are imported into sections as shown in the attached image.

[DataTypeManager.bmp](https://github.com/user-attachments/files/28730083/DataTypeManager.bmp)

This was tested with the following environment:
Binary: https://github.com/ghidraninja/arm-bare-metal-1
SVD file: https://github.com/cmsis-svd/cmsis-svd-data/blob/main/data/STMicro/STM32F446.svd
Ghidra version: 12.1.2 from https://github.com/NationalSecurityAgency/ghidra
GhidraSVD version:  0.6.1
The binary was loaded at address 0x08000000 with rx permissions. An SRAM region from 0x20000000 was added ending at the main stack pointer (first 4 bytes of the binary).

p.s. Thank you Antonio for creating GhidraSVD. I stumbled upon this after listening to a recording of your conference talk at 39C3. Fantastic work.